### PR TITLE
Update apache config to first show modern access control

### DIFF
--- a/04.web-servers/01.apache.md
+++ b/04.web-servers/01.apache.md
@@ -3,6 +3,38 @@
 
 You need at least the following setup:
 
+
+```
+<VirtualHost *:80>
+  ServerName example.com
+  ServerAlias example.com www.example.com
+  ServerAdmin me@example.com
+  DocumentRoot /var/www/html/example_com
+  ErrorLog /var/log/httpd/example_com_error
+  CustomLog /var/log/httpd/example_com_access common
+
+  <Directory "/var/www/html/example_com">
+    Options FollowSymLinks Indexes
+    AllowOverride All
+    Require all granted
+    DirectoryIndex index.php
+  </Directory>
+
+  # Block access to .ini and .md files
+  <FilesMatch "\.(ini|md)$">
+    Require all denied
+  </FilesMatch>
+
+  # Block access to content/data folder
+  <Directory "/var/www/html/example_com/content/data">
+    Require all denied
+  </Directory>
+
+</VirtualHost>
+```
+
+For Apache httpd Versions before 2.4 use this setup:
+
 ```
 <VirtualHost *:80>
   ServerName example.com
@@ -35,36 +67,6 @@ You need at least the following setup:
 </VirtualHost>
 ```
 
-**Note:** if got `AH01630: client denied by server configuration` error. Please use below:
-
-```
-<VirtualHost *:80>
-  ServerName example.com
-  ServerAlias example.com www.example.com
-  ServerAdmin me@example.com
-  DocumentRoot /var/www/html/example_com
-  ErrorLog /var/log/httpd/example_com_error
-  CustomLog /var/log/httpd/example_com_access common
-
-  <Directory "/var/www/html/example_com">
-    Options FollowSymLinks Indexes
-    AllowOverride All
-    Require all granted
-    DirectoryIndex index.php
-  </Directory>
-
-  # Block access to .ini and .md files
-  <FilesMatch "\.(ini|md)$">
-    Require all denied
-  </FilesMatch>
-
-  # Block access to content/data folder
-  <Directory "/var/www/html/example_com/content/data">
-    Require all denied
-  </Directory>
-
-</VirtualHost>
-```
 
 Credit: [@ProjectPatatoe](https://github.com/ProjectPatatoe)
 


### PR DESCRIPTION
Apache httpd version 2.4 was in debain stable since 2015, the older syntax should be avoided for new setups.